### PR TITLE
Update Sonos Developer APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-41BDF5.svg)](https://github.com/hacs/integration)
 
-The `sonos_cloud` integration uses the cloud-based [Sonos Control API](https://developer.sonos.com/reference/control-api/) to send [audioClip](https://developer.sonos.com/reference/control-api/audioclip/) commands to speakers. This allows playback of short clips (e.g., alert sounds, TTS messages) on Sonos speakers without interrupting playback. Audio played in this manner will reduce the volume of currently playing music, play the clip on top of the music, and then automatically return the music to its original volume. This is an alternative approach to the current method which requires taking snapshots & restoring speakers with complex scripts and automations.
+The `sonos_cloud` integration uses the cloud-based [Sonos Control API](https://docs.sonos.com/docs/control) to send [audioClip](https://docs.sonos.com/reference/audioclip-loadaudioclip-playerid) commands to speakers. This allows playback of short clips (e.g., alert sounds, TTS messages) on Sonos speakers without interrupting playback. Audio played in this manner will reduce the volume of currently playing music, play the clip on top of the music, and then automatically return the music to its original volume. This is an alternative approach to the current method which requires taking snapshots & restoring speakers with complex scripts and automations.
 
 This API requires audio files to be in `.mp3` or `.wav` format and to have publicly accessible URLs.
 
@@ -152,4 +152,4 @@ tts:
 
 ## Secure connections
 
-Sonos devices have strict security requirements if served media over an SSL/TLS connection. See more details here: https://developer.sonos.com/build/content-service-get-started/security/.
+Sonos devices have strict security requirements if served media over an SSL/TLS connection. [See more details here](https://docs.sonos.com/docs/security).


### PR DESCRIPTION
Clicking the Sonos Developer API links would send you to the login page then actually break because the links are obsolete, now it directs you to a public page so you can read about what the Sonos Cloud extension is about without thinking you need an account